### PR TITLE
Re-arrange Rinkeby and Mainnet links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Contracts
 ### Mainnet
-- EC Registry V2 - https://rinkeby.etherscan.io/address/0xE4EbA7dcD0C3F0D62f39A8573655531f864F54b5
-- Zoom Batch Caller - https://rinkeby.etherscan.io/address/0x5B4B84F5A862A0EAb7a1B8B04946B5947BCEd28c
+- EC Registry V2 - https://etherscan.io/address/0x4fcB9b38CAC63957C8877667B0aDB9207c890a13
+- Zoom Batch Caller - https://etherscan.io/address/0x7cdF091AF6a9ED75E3192500d3e5BB0f63e22Dea
 
 
 ### Rinkeby
-- EC Registry V2 - https://etherscan.io/address/0x4fcB9b38CAC63957C8877667B0aDB9207c890a13
-- Zoom Batch Caller - https://etherscan.io/address/0x7cdF091AF6a9ED75E3192500d3e5BB0f63e22Dea
+- EC Registry V2 - https://rinkeby.etherscan.io/address/0xE4EbA7dcD0C3F0D62f39A8573655531f864F54b5
+- Zoom Batch Caller - https://rinkeby.etherscan.io/address/0x5B4B84F5A862A0EAb7a1B8B04946B5947BCEd28c
 
 
 ### Frontend testnet utils


### PR DESCRIPTION
README contract links were out of order.